### PR TITLE
Add help text to registration form

### DIFF
--- a/ui/forms.py
+++ b/ui/forms.py
@@ -51,7 +51,11 @@ class ContactForm(forms.Form):
 
 
 class CompanyForm(forms.Form):
-    company_number = forms.CharField(label='Company number')
+    company_number = forms.CharField(
+        label='Company number',
+        help_text=('This is the 8-digit number on the company certificate of '
+                   'incorporation.'),
+    )
     company_email = forms.EmailField()
     company_email_confirmed = forms.EmailField()
     terms_agreed = forms.BooleanField()


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-35?focusedCommentId=11507&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-11507)

Note I have not included the help text on the email because the requirements on the email are still in flux. Once we pin those down some more I shall do a follow up PR.

Similarly there is currently no restriction on the user regarding the format of their password. Django does also not enforce a maximum length on passwords, so I have left the password help text blank too.

![image](https://cloud.githubusercontent.com/assets/5485798/19083402/d474d326-8a59-11e6-8b07-979ca40cb769.png)