### PR TITLE
Registration email confirmation skeleton

### DIFF
--- a/ui/clients/directory_api.py
+++ b/ui/clients/directory_api.py
@@ -1,0 +1,14 @@
+class RemoteError(Exception):
+    pass
+
+
+class DirectoryAPIClient(object):
+
+    RemoteError = RemoteError
+
+    def acknowledge_email_confirmed(self, identifier):
+        # todo: raise a RemoteError if acknowledgement fails
+        pass
+
+
+client = DirectoryAPIClient()

--- a/ui/clients/directory_api.py
+++ b/ui/clients/directory_api.py
@@ -1,14 +1,8 @@
-class RemoteError(Exception):
-    pass
-
-
 class DirectoryAPIClient(object):
 
-    RemoteError = RemoteError
-
-    def acknowledge_email_confirmed(self, identifier):
-        # todo: raise a RemoteError if acknowledgement fails
-        pass
+    def confirm_email(self, identifier):
+        # todo: return False if acknowledgement fails
+        return True
 
 
-client = DirectoryAPIClient()
+api_client = DirectoryAPIClient()

--- a/ui/templates/confirm-email-error.html
+++ b/ui/templates/confirm-email-error.html
@@ -1,0 +1,1 @@
+There was a problem confirming your email address.

--- a/ui/templates/confirm-email-success.html
+++ b/ui/templates/confirm-email-success.html
@@ -1,0 +1,1 @@
+Email address confirmed!

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -1,9 +1,11 @@
+import http
 from unittest import mock
 
 from django.core.urlresolvers import reverse
 from django.test import override_settings
 
-from ui.views import IndexView
+from ui.clients.directory_api import client
+from ui.views import EmailConfirmationView, IndexView
 
 VALID_REQUEST_DATA = {
     "contact_name": "Test",
@@ -31,3 +33,32 @@ def test_index_view_create(rf):
         response = view(request)
 
     assert response.url == reverse('thanks')
+
+
+def test_email_confirm_missing_identifier(rf):
+    view = EmailConfirmationView.as_view()
+    request = rf.get(reverse('confirm-email'))
+    response = view(request)
+    assert response.status_code == http.client.FOUND
+    assert response.get('Location') == reverse('confirm-email-error')
+
+
+@mock.patch.object(client, 'acknowledge_email_confirmed',
+                   side_effect=client.RemoteError)
+def test_email_confirm_invalid_identifier(mock_acknowledge_email_confirmed, rf):
+    view = EmailConfirmationView.as_view()
+    request = rf.get(reverse('confirm-email'), {'identifier': 123})
+    response = view(request)
+    assert mock_acknowledge_email_confirmed.called_with(123)
+    assert response.status_code == http.client.FOUND
+    assert response.get('Location') == reverse('confirm-email-error')
+
+
+@mock.patch.object(client, 'acknowledge_email_confirmed')
+def test_email_confirm_valid_identifier(mock_acknowledge_email_confirmed, rf):
+    view = EmailConfirmationView.as_view()
+    request = rf.get(reverse('confirm-email'), {'identifier': 123})
+    response = view(request)
+    assert mock_acknowledge_email_confirmed.called_with(123)
+    assert response.status_code == http.client.FOUND
+    assert response.get('Location') == reverse('confirm-email-success')

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.core.urlresolvers import reverse
 from django.test import override_settings
 
-from ui.clients.directory_api import client
+from ui.clients.directory_api import api_client
 from ui.views import EmailConfirmationView, IndexView
 
 VALID_REQUEST_DATA = {
@@ -35,7 +35,7 @@ def test_index_view_create(rf):
     assert response.url == reverse('thanks')
 
 
-def test_email_confirm_missing_identifier(rf):
+def test_email_confirm_missing_confirmation_code(rf):
     view = EmailConfirmationView.as_view()
     request = rf.get(reverse('confirm-email'))
     response = view(request)
@@ -43,22 +43,21 @@ def test_email_confirm_missing_identifier(rf):
     assert response.template_name == EmailConfirmationView.failure_template
 
 
-@mock.patch.object(client, 'acknowledge_email_confirmed',
-                   side_effect=client.RemoteError)
-def test_email_confirm_invalid_identifier(mock_acknowledge_email_confirmed, rf):
+@mock.patch.object(api_client, 'confirm_email', return_value=False)
+def test_email_confirm_invalid_confirmation_code(mock_confirm_email, rf):
     view = EmailConfirmationView.as_view()
-    request = rf.get(reverse('confirm-email'), {'identifier': 123})
+    request = rf.get(reverse('confirm-email'), {'confirmation_code': 123})
     response = view(request)
-    assert mock_acknowledge_email_confirmed.called_with(123)
+    assert mock_confirm_email.called_with(123)
     assert response.status_code == http.client.OK
     assert response.template_name == EmailConfirmationView.failure_template
 
 
-@mock.patch.object(client, 'acknowledge_email_confirmed')
-def test_email_confirm_valid_identifier(mock_acknowledge_email_confirmed, rf):
+@mock.patch.object(api_client, 'confirm_email', return_value=True)
+def test_email_confirm_valid_confirmation_code(mock_confirm_email, rf):
     view = EmailConfirmationView.as_view()
-    request = rf.get(reverse('confirm-email'), {'identifier': 123})
+    request = rf.get(reverse('confirm-email'), {'confirmation_code': 123})
     response = view(request)
-    assert mock_acknowledge_email_confirmed.called_with(123)
+    assert mock_confirm_email.called_with(123)
     assert response.status_code == http.client.OK
     assert response.template_name == EmailConfirmationView.success_template

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -39,8 +39,8 @@ def test_email_confirm_missing_identifier(rf):
     view = EmailConfirmationView.as_view()
     request = rf.get(reverse('confirm-email'))
     response = view(request)
-    assert response.status_code == http.client.FOUND
-    assert response.get('Location') == reverse('confirm-email-error')
+    assert response.status_code == http.client.OK
+    assert response.template_name == EmailConfirmationView.failure_template
 
 
 @mock.patch.object(client, 'acknowledge_email_confirmed',
@@ -50,8 +50,8 @@ def test_email_confirm_invalid_identifier(mock_acknowledge_email_confirmed, rf):
     request = rf.get(reverse('confirm-email'), {'identifier': 123})
     response = view(request)
     assert mock_acknowledge_email_confirmed.called_with(123)
-    assert response.status_code == http.client.FOUND
-    assert response.get('Location') == reverse('confirm-email-error')
+    assert response.status_code == http.client.OK
+    assert response.template_name == EmailConfirmationView.failure_template
 
 
 @mock.patch.object(client, 'acknowledge_email_confirmed')
@@ -60,5 +60,5 @@ def test_email_confirm_valid_identifier(mock_acknowledge_email_confirmed, rf):
     request = rf.get(reverse('confirm-email'), {'identifier': 123})
     response = view(request)
     assert mock_acknowledge_email_confirmed.called_with(123)
-    assert response.status_code == http.client.FOUND
-    assert response.get('Location') == reverse('confirm-email-success')
+    assert response.status_code == http.client.OK
+    assert response.template_name == EmailConfirmationView.success_template

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -30,3 +30,4 @@ urlpatterns = [
         name='register'),
 
 ]
+

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -34,16 +34,4 @@ urlpatterns = [
         EmailConfirmationView.as_view(),
         name='confirm-email'),
 
-    url(r'^confirm-email/error$',
-        cache_me(CachableTemplateView.as_view(
-            template_name='email-confirm-error.html'
-        )),
-        name='confirm-email-error'),
-
-    url(r'^confirm-email/success$',
-        cache_me(CachableTemplateView.as_view(
-            template_name='email-confirm-success.html'
-        )),
-        name='confirm-email-success'),
-
 ]

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -3,8 +3,9 @@ from django.views.decorators.cache import cache_page
 
 from ui.views import (
     CachableTemplateView,
-    RegisterView,
+    EmailConfirmationView,
     IndexView,
+    RegisterView,
 )
 
 
@@ -29,5 +30,20 @@ urlpatterns = [
         RegisterView.as_view(),
         name='register'),
 
-]
+    url(r'^confirm-email$',
+        EmailConfirmationView.as_view(),
+        name='confirm-email'),
 
+    url(r'^confirm-email/error$',
+        cache_me(CachableTemplateView.as_view(
+            template_name='email-confirm-error.html'
+        )),
+        name='confirm-email-error'),
+
+    url(r'^confirm-email/success$',
+        cache_me(CachableTemplateView.as_view(
+            template_name='email-confirm-success.html'
+        )),
+        name='confirm-email-success'),
+
+]

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -5,7 +5,7 @@ from ui.views import (
     CachableTemplateView,
     EmailConfirmationView,
     IndexView,
-    RegisterView,
+    RegistrationView,
 )
 
 
@@ -27,7 +27,7 @@ urlpatterns = [
         name="terms"),
 
     url(r'^register$',
-        RegisterView.as_view(),
+        RegistrationView.as_view(),
         name='register'),
 
     url(r'^confirm-email$',

--- a/ui/views.py
+++ b/ui/views.py
@@ -74,5 +74,7 @@ class EmailConfirmationView(View):
     def get(self, request):
         confirmation_code = request.GET.get('confirmation_code')
         if confirmation_code and api_client.confirm_email(confirmation_code):
-            return TemplateResponse(request, self.success_template)
-        return TemplateResponse(request, self.failure_template)
+            template = self.success_template
+        else:
+            template = self.failure_template
+        return TemplateResponse(request, template)

--- a/ui/views.py
+++ b/ui/views.py
@@ -62,3 +62,13 @@ class RegisterView(SessionWizardView):
 
     def done(self, form_list, form_dict):
         return render(self.request, 'registered.html')
+
+
+class EmailConfirmationView(View):
+
+    def get(self, request):
+        if 'identifier' in request.GET:
+            identifier = request.GET['identifier']
+            with api_client.acknowledge_email_confirmed(identifier=identifier):
+                return redirect('email-confirm-success')
+        return redirect('email-confirm-failure')


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-124)

The view will be used when users click the 'confirm your email address' link in the email the API server sends the user.

The view will then show either a "success" or "failure" message depending on if the API client raises a `RemoteError`