### PR TITLE
Remove unwanted template content

### DIFF
--- a/ui/templates/govuk_layout.html
+++ b/ui/templates/govuk_layout.html
@@ -64,20 +64,8 @@
 				</div>
 			</div>
 		</header>
-
-
-		<div id="global-header-bar"></div>
 	
 		<div id="content">
-
-			<div class="grid-row">
-				<div class="column-two-thirds">
-					
-					<a href="https://www.exportingisgreat.gov.uk/">
-						<img class="exporting-logo" src="{% static 'images/exporting-is-great-logo.png' %}" alt="Exporting is Great" height="100">
-					</a>
-				</div>
-
 			{% block content %}
 			{% endblock content %}
 			</div>


### PR DESCRIPTION
Makes the template more in line with the design.

Results in this:

![image](https://cloud.githubusercontent.com/assets/5485798/19156658/9be8e538-8bda-11e6-8fe7-5188d2d293a4.png)


instead of this:

![image](https://cloud.githubusercontent.com/assets/5485798/19156682/b0473d0e-8bda-11e6-8fb9-1c39ac423fe0.png)
