### PR TITLE
Add IE8 support for 'current step' indicator

### DIFF
--- a/ui/static/sass/main.scss
+++ b/ui/static/sass/main.scss
@@ -171,21 +171,9 @@ body {
         margin: 20px auto;
         text-align: center;
         width: 100%;
-        .step {
-          background: #ffffff;
-          border: 1px solid #ffffff;
-          border-radius: 15px;
-          display: inline-block;
-          height: 15px;
-          margin: 0 5px;
-          width: 15px;
-
-          &.active {
-            
-          }
-          &.not-active {
-            background: rgba(0,0,0,0);
-          }
+        color: white;
+        span {
+          font-size: 3em;
         }
       }
     }

--- a/ui/templates/form-wrapper.html
+++ b/ui/templates/form-wrapper.html
@@ -35,13 +35,12 @@
 
 		<div class="already-registered">Already registered? <a href="#">Sign in</a></div>
 
-		
 		<div class="steps">
-			{% for index in '01' %}
-				{% if wizard.steps.current == index %}
-					<div class="step active"></div>
+			{% for step_index in wizard.steps.all %}
+				{% if wizard.steps.current == step_index %}
+					<span>&#9679;</span>
 				{% else %}
-					<div class="step not-active"></div>
+					<span>&#9675;</span>
 				{% endif %}
 			{% endfor %}
 

--- a/ui/templates/form-wrapper.html
+++ b/ui/templates/form-wrapper.html
@@ -36,8 +36,8 @@
 		<div class="already-registered">Already registered? <a href="#">Sign in</a></div>
 
 		<div class="steps">
-			{% for step_index in wizard.steps.all %}
-				{% if wizard.steps.current == step_index %}
+			{% for step in wizard.steps.all %}
+				{% if wizard.steps.current == step %}
 					<span>&#9679;</span>
 				{% else %}
 					<span>&#9675;</span>


### PR DESCRIPTION
[part of this task](https://uktrade.atlassian.net/browse/ED-127)

Replace css cirlce rendering with the humble ● and ○ characters because IE8 does not support css circles.

Before:
![image](https://cloud.githubusercontent.com/assets/5485798/19160473/e6c0a7be-8be7-11e6-9391-ff53d5203470.png)


After:

![image](https://cloud.githubusercontent.com/assets/5485798/19160422/b9658532-8be7-11e6-9d08-b5c337abe13f.png)