### PR TITLE
Include referrer in the registration form

### DIFF
--- a/ui/constants.py
+++ b/ui/constants.py
@@ -4,3 +4,5 @@ AIMS = (
     ('ANSWER2', 'Answer 2'),
     ('OTHER', 'Other')
 )
+
+SESSION_KEY_REFERRER = 'REFERRER'

--- a/ui/forms.py
+++ b/ui/forms.py
@@ -23,3 +23,4 @@ class UserForm(forms.Form):
     email = forms.EmailField(label='Email address')
     password = forms.CharField(widget=forms.PasswordInput())
     terms_agreed = forms.BooleanField()
+    referrer = forms.CharField(required=False, widget=forms.HiddenInput())

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -1,4 +1,4 @@
 def get_referrer_from_request(request):
-    # determine what source led the user to the export directory
-    # if navigating internally then return None
+    # TODO: determine what source led the user to the export directory
+    # if navigating internally then return None (ticket ED-138)
     return 'aaa'

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -1,0 +1,4 @@
+def get_referrer_from_request(request):
+    # determine what source led the user to the export directory
+    # if navigating internally then return None
+    return 'aaa'

--- a/ui/middleware.py
+++ b/ui/middleware.py
@@ -1,8 +1,10 @@
 import sys
 
+from django.conf import settings
 from urllib.parse import urlsplit, urlunsplit
-
 from django.http import HttpResponseRedirect
+
+from ui import helpers
 
 
 class SSLRedirectMiddleware:
@@ -12,3 +14,10 @@ class SSLRedirectMiddleware:
             if "runserver" not in sys.argv and "test" not in sys.argv:
                 return HttpResponseRedirect(urlunsplit(
                     ["https"] + list(urlsplit(request.get_raw_uri())[1:])))
+
+
+class ReferrerMiddleware(object):
+    def process_request(self, request):
+        referrer = helpers.get_referrer_from_request(request)
+        if referrer:
+            request.session[settings.SESSION_KEY_REFERRER] = referrer

--- a/ui/middleware.py
+++ b/ui/middleware.py
@@ -1,10 +1,10 @@
 import sys
 
-from django.conf import settings
 from urllib.parse import urlsplit, urlunsplit
 from django.http import HttpResponseRedirect
 
 from ui import helpers
+from ui.constants import SESSION_KEY_REFERRER
 
 
 class SSLRedirectMiddleware:
@@ -20,4 +20,4 @@ class ReferrerMiddleware(object):
     def process_request(self, request):
         referrer = helpers.get_referrer_from_request(request)
         if referrer:
-            request.session[settings.SESSION_KEY_REFERRER] = referrer
+            request.session[SESSION_KEY_REFERRER] = referrer

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -48,6 +48,7 @@ MIDDLEWARE_CLASSES = [
     # 'ui.middleware.SSLRedirectMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'ui.middleware.ReferrerMiddleware',
 ]
 
 ROOT_URLCONF = 'ui.urls'
@@ -120,3 +121,5 @@ RAVEN_CONFIG = {
     # release based on the git info.
     # 'release': raven.fetch_git_sha(os.path.dirname(__file__)),
 }
+
+SESSION_KEY_REFERRER = 'REFERRER'

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -121,5 +121,3 @@ RAVEN_CONFIG = {
     # release based on the git info.
     # 'release': raven.fetch_git_sha(os.path.dirname(__file__)),
 }
-
-SESSION_KEY_REFERRER = 'REFERRER'

--- a/ui/tests/test_middleware.py
+++ b/ui/tests/test_middleware.py
@@ -1,0 +1,58 @@
+from unittest import mock
+
+from django.conf import settings
+
+from ui import helpers, middleware
+
+
+@mock.patch.object(helpers, 'get_referrer_from_request', return_value='google')
+def test_referrer_stored_in_session_if_known(
+    mock_get_referrer_from_request, rf
+):
+    request = rf.get('/')
+    request.session = {}
+    instance = middleware.ReferrerMiddleware()
+
+    instance.process_request(request)
+
+    assert request.session[settings.SESSION_KEY_REFERRER] == 'google'
+
+
+@mock.patch.object(helpers, 'get_referrer_from_request', return_value=None)
+def test_bail_out_on_unknown_referrrer(
+    mock_get_referrer_from_request, rf
+):
+    request = rf.get('/')
+    request.session = {}
+    instance = middleware.ReferrerMiddleware()
+
+    instance.process_request(request)
+
+    assert settings.SESSION_KEY_REFERRER not in request.session
+
+
+@mock.patch.object(helpers, 'get_referrer_from_request', return_value=None)
+def test_internal_browsing_once_not_overwrite_referrer(
+    mock_get_referrer_from_request, rf
+):
+    request = rf.get('/')
+    request.session = {settings.SESSION_KEY_REFERRER: 'google'}
+    instance = middleware.ReferrerMiddleware()
+
+    instance.process_request(request)
+
+    assert request.session[settings.SESSION_KEY_REFERRER] == 'google'
+
+
+@mock.patch.object(helpers, 'get_referrer_from_request', return_value=None)
+def test_internal_browsing_multiple_not_overwrite_referrer(
+    mock_get_referrer_from_request, rf
+):
+    request = rf.get('/')
+    request.session = {settings.SESSION_KEY_REFERRER: 'google'}
+    instance = middleware.ReferrerMiddleware()
+
+    instance.process_request(request)
+    instance.process_request(request)
+
+    assert request.session[settings.SESSION_KEY_REFERRER] == 'google'

--- a/ui/tests/test_middleware.py
+++ b/ui/tests/test_middleware.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from django.conf import settings
+from ui.constants import SESSION_KEY_REFERRER
 
 from ui import helpers, middleware
 
@@ -15,7 +15,7 @@ def test_referrer_stored_in_session_if_known(
 
     instance.process_request(request)
 
-    assert request.session[settings.SESSION_KEY_REFERRER] == 'google'
+    assert request.session[SESSION_KEY_REFERRER] == 'google'
 
 
 @mock.patch.object(helpers, 'get_referrer_from_request', return_value=None)
@@ -28,7 +28,7 @@ def test_bail_out_on_unknown_referrrer(
 
     instance.process_request(request)
 
-    assert settings.SESSION_KEY_REFERRER not in request.session
+    assert SESSION_KEY_REFERRER not in request.session
 
 
 @mock.patch.object(helpers, 'get_referrer_from_request', return_value=None)
@@ -36,12 +36,12 @@ def test_internal_browsing_once_not_overwrite_referrer(
     mock_get_referrer_from_request, rf
 ):
     request = rf.get('/')
-    request.session = {settings.SESSION_KEY_REFERRER: 'google'}
+    request.session = {SESSION_KEY_REFERRER: 'google'}
     instance = middleware.ReferrerMiddleware()
 
     instance.process_request(request)
 
-    assert request.session[settings.SESSION_KEY_REFERRER] == 'google'
+    assert request.session[SESSION_KEY_REFERRER] == 'google'
 
 
 @mock.patch.object(helpers, 'get_referrer_from_request', return_value=None)
@@ -49,10 +49,10 @@ def test_internal_browsing_multiple_not_overwrite_referrer(
     mock_get_referrer_from_request, rf
 ):
     request = rf.get('/')
-    request.session = {settings.SESSION_KEY_REFERRER: 'google'}
+    request.session = {SESSION_KEY_REFERRER: 'google'}
     instance = middleware.ReferrerMiddleware()
 
     instance.process_request(request)
     instance.process_request(request)
 
-    assert request.session[settings.SESSION_KEY_REFERRER] == 'google'
+    assert request.session[SESSION_KEY_REFERRER] == 'google'

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -5,7 +5,6 @@ import pytest
 
 from django.core.urlresolvers import reverse
 
-from ui import forms
 from ui.clients.directory_api import api_client
 from ui.constants import SESSION_KEY_REFERRER
 from ui.views import EmailConfirmationView, RegistrationView
@@ -45,8 +44,10 @@ def test_registration_view_includes_referrer(client, rf):
     request.session = client.session
     request.session[SESSION_KEY_REFERRER] = 'google'
 
-    view = RegistrationView.as_view(form_list=(('user', forms.UserForm),))
+    form_pair = RegistrationView.form_list[2]
+    view = RegistrationView.as_view(form_list=(form_pair,))
     response = view(request)
 
     initial = response.context_data['form'].initial
+    assert form_pair[0] == 'user'
     assert initial['referrer'] == 'google'

--- a/ui/views.py
+++ b/ui/views.py
@@ -6,6 +6,7 @@ from django.views.generic import TemplateView
 from django.views.generic.base import View
 
 from ui import forms
+from ui.constants import SESSION_KEY_REFERRER
 from ui.clients.directory_api import api_client
 
 
@@ -29,9 +30,9 @@ class CachableTemplateView(CacheMixin, TemplateView):
 
 class RegistrationView(SessionWizardView):
     form_list = (
-        forms.CompanyForm,
-        forms.AimsForm,
-        forms.UserForm,
+        ('company', forms.CompanyForm),
+        ('aims', forms.AimsForm),
+        ('user', forms.UserForm),
     )
 
     def get_template_names(self):
@@ -40,6 +41,12 @@ class RegistrationView(SessionWizardView):
             'aims-form.html',
             'user-form.html',
         ]
+
+    def get_form_initial(self, step):
+        if step == 'user':
+            return {
+                'referrer': self.request.session.get(SESSION_KEY_REFERRER)
+            }
 
     def done(self, form_list, form_dict):
         return TemplateResponse(self.request, 'registered.html')


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-133).and [this task](https://uktrade.atlassian.net/browse/ED-134)

In the user's session we store the source that led the user to the export directory, then on the final registration form we include the referrer from the session.

Outcome is the following:

![image](https://cloud.githubusercontent.com/assets/5485798/19193798/701dc4ea-8ca3-11e6-9aea-e7dfb45c6518.png)

For now we stub the function that determines the referrer.