### PR TITLE
Send company profile data to API on submit

### DIFF
--- a/registration/forms.py
+++ b/registration/forms.py
@@ -60,3 +60,20 @@ def serialize_registration_forms(cleaned_data):
         'password': cleaned_data['password'],
         'referrer': cleaned_data['referrer'],
     }
+
+
+def serialize_company_profile_forms(cleaned_data):
+    """
+    Return the shape directory-api-client expects for registration.
+
+    @param {dict} cleaned_data - All the fields in `CompanyBasicInfoForm`
+    @returns dict
+
+    """
+
+    return {
+        'name': cleaned_data['company_name'],
+        'website': cleaned_data['website'],
+        'description': cleaned_data['description'],
+        'logo': cleaned_data['logo']
+    }

--- a/registration/templates/company-profile-update-error.html
+++ b/registration/templates/company-profile-update-error.html
@@ -1,0 +1,4 @@
+{% extends 'registration-base.html' %}
+
+{% block hero_title %}There was a problem updating your profile.{% endblock %}
+{% block hero_text %}Please try again.{% endblock %}

--- a/registration/tests/test_forms.py
+++ b/registration/tests/test_forms.py
@@ -185,3 +185,20 @@ def test_serialize_registration_forms():
         'referrer': 'google'
     }
     assert actual == expected
+
+
+def test_serialize_company_profile_forms():
+    logo = create_file_of_size(1)
+    actual = forms.serialize_company_profile_forms({
+        'company_name': 'Example ltd.',
+        'website': 'http://example.com',
+        'description': 'Jolly good exporter.',
+        'logo': logo,
+    })
+    expected = {
+        'name': 'Example ltd.',
+        'website': 'http://example.com',
+        'description': 'Jolly good exporter.',
+        'logo': logo
+    }
+    assert actual == expected

--- a/registration/views.py
+++ b/registration/views.py
@@ -106,11 +106,19 @@ class CompanyProfileEditView(SessionWizardView):
     file_storage = FileSystemStorage(
         location=os.path.join(settings.MEDIA_ROOT, 'tmp-logos')
     )
+    failure_template = 'company-profile-update-error.html'
 
     def get_template_names(self):
         return [
             'company-profile-form.html',
         ]
 
-    def done(self, form_list, form_dict):
-        return redirect('company-detail')
+    def done(self, *args, **kwargs):
+
+        data = forms.serialize_company_profile_forms(self.get_all_cleaned_data())
+        response = api_client.company.update_profile(data)
+        if response.status_code == http.client.OK:
+            response = redirect('company-detail')
+        else:
+            response = TemplateResponse(self.request, self.failure_template)
+        return response


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-176)

will change this PR against master once [this](https://github.com/uktrade/directory-ui/pull/41) is merged.

once directory-api-client has stabilised we can install and use that client, but for now I have stubbed it with a mock. Will do a follow up PR to replace.