### PR TITLE
Expose current logged in user id to api when retrieving the user details

### DIFF
--- a/user/tests/test_views.py
+++ b/user/tests/test_views.py
@@ -11,10 +11,9 @@ from user.views import UserProfileDetailView
 def test_user_profile_details_calls_api(mock_retrieve_profile, rf):
     view = UserProfileDetailView.as_view()
     request = rf.get(reverse('user-detail'))
+    request.user = mock.Mock(id=1)
     view(request)
-    # TODO: ED-183
-    # update test once no longer hard-coding the user id
-    assert mock_retrieve_profile.called_once()
+    assert mock_retrieve_profile.called_once_with(1)
 
 
 @mock.patch.object(api_client.user, 'retrieve_profile')
@@ -25,6 +24,7 @@ def test_user_profile_details_exposes_context(mock_retrieve_profile, rf):
     }
     view = UserProfileDetailView.as_view()
     request = rf.get(reverse('user-detail'))
+    request.user = mock.Mock(id=1)
     response = view(request)
     assert response.status_code == http.client.OK
     assert response.template_name == [UserProfileDetailView.template_name]

--- a/user/views.py
+++ b/user/views.py
@@ -7,9 +7,7 @@ class UserProfileDetailView(TemplateView):
     template_name = 'user-profile-details.html'
 
     def get_context_data(self, **kwargs):
-        # TODO: ED-183
-        # Determine the user_id of the logged in user.
-        user_id = 1
+        user_id = self.request.user.id
         user_details = api_client.user.retrieve_profile(id=user_id)
         return {
             'user': {


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-183)

Note this will make the view break until we implement a user backend that returns a mock user (follow up task).