### PR TITLE
Fix populating company name from companies house

### DIFF
--- a/enrolment/forms.py
+++ b/enrolment/forms.py
@@ -283,7 +283,6 @@ def serialize_company_logo_forms(cleaned_data):
     Return the shape directory-api-client expects for changing logo.
 
     @param {dict} cleaned_data - All the fields in `CompanyLogoForm`
-
     @returns dict
 
     """
@@ -298,7 +297,6 @@ def serialize_company_description_forms(cleaned_data):
     Return the shape directory-api-client expects for changing description.
 
     @param {dict} cleaned_data - All the fields in `CompanyDescriptionForm`
-
     @returns dict
 
     """
@@ -314,7 +312,6 @@ def serialize_international_buyer_forms(cleaned_data):
     buyers.
 
     @param {dict} cleaned_data - All the fields in `InternationalBuyerForm`
-
     @returns dict
 
     """
@@ -323,4 +320,32 @@ def serialize_international_buyer_forms(cleaned_data):
         'name': cleaned_data['full_name'],
         'email': cleaned_data['email_address'],
         'sector': cleaned_data['sector'],
+    }
+
+
+def get_company_name_form_initial_data(name):
+    """
+    Returns the shape of initial data that CompanyNameForm expects.
+
+    @param {str} name
+    @returns dict
+
+    """
+
+    return {
+        'name': name,
+    }
+
+
+def get_user_form_initial_data(referrer):
+    """
+    Returns the shape of initial data that UserForm expects.
+
+    @param {str} referrer
+    @returns dict
+
+    """
+
+    return {
+        'referrer': referrer,
     }

--- a/enrolment/tests/test_forms.py
+++ b/enrolment/tests/test_forms.py
@@ -319,3 +319,23 @@ def test_serialize_international_buyer_forms():
         'sector': 'AEROSPACE',
     }
     assert actual == expected
+
+
+def test_get_company_name_form_initial_data():
+    actual = forms.get_company_name_form_initial_data(
+        name='Example'
+    )
+    expected = {
+        'name': 'Example'
+    }
+    assert actual == expected
+
+
+def test_get_user_form_initial_data():
+    actual = forms.get_user_form_initial_data(
+        referrer='google'
+    )
+    expected = {
+        'referrer': 'google'
+    }
+    assert actual == expected

--- a/enrolment/views.py
+++ b/enrolment/views.py
@@ -104,15 +104,12 @@ class EnrolmentView(SSOLoginRequiredMixin, SessionWizardView):
     def get_form_initial(self, step):
         if step == 'user':
             referrer = self.request.session.get(constants.SESSION_KEY_REFERRER)
-            return {
-                'referrer': referrer
-            }
+            return forms.get_user_form_initial_data(referrer=referrer)
         if step == 'name':
             prev_data = self.storage.get_step_data('company') or {}
             company_number = prev_data.get('company-company_number')
-            return {
-                'company_name': helpers.get_company_name(company_number)
-            }
+            name = helpers.get_company_name(company_number)
+            return forms.get_company_name_form_initial_data(name=name)
 
     def process_step(self, form):
         step = self.storage.current_step


### PR DESCRIPTION
## Regression autopsy

### Introduced by 
In https://github.com/uktrade/directory-ui/pull/197 we renamed `UserForm.company_name` to `UserForm.name`. `views.py` sets the initial data of `UserForm`, but the initial data structure was not updated to reflect this name change, so `views.py` was telling the form that 'company_name is "example"', but this was ignoring this because the form no longer has a field called 'company_name`


### Remediation and lesson learned 
`views.py` should not know about the structure of the forms it uses, so we moved the 'get form initial data' code to `forms.py`, where the helper function can easily be updated if the form field names change again.

### Proof in the pudding
![image](https://cloud.githubusercontent.com/assets/5485798/20240749/57964668-a918-11e6-85d5-3528bc31c52f.png)
