### PR TITLE
Add dummy api client for testing

### DIFF
--- a/api_client/__init__.py
+++ b/api_client/__init__.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+
+ClientClass = import_string(settings.API_CLIENT_CLASS)
+api_client = ClientClass(
+    base_url=settings.API_CLIENT_BASE_URL,
+    api_key=settings.API_CLIENT_KEY,
+)

--- a/docker/env.json
+++ b/docker/env.json
@@ -5,6 +5,7 @@
     "required": [
       "API_CLIENT_BASE_URL",
       "API_CLIENT_KEY",
+      "API_CLIENT_CLASS_NAME",
       "COMPANIES_HOUSE_SEARCH_URL",
       "DEBUG",
       "PORT",

--- a/docker/env.test.json
+++ b/docker/env.test.json
@@ -5,6 +5,7 @@
     "required": [
       "API_CLIENT_BASE_URL",
       "API_CLIENT_KEY",
+      "API_CLIENT_CLASS_NAME",
       "COMPANIES_HOUSE_SEARCH_URL",
       "DEBUG",
       "PORT",

--- a/enrolment/helpers.py
+++ b/enrolment/helpers.py
@@ -1,12 +1,5 @@
-from directory_api_client.client import DirectoryAPIClient
+from api_client import api_client
 from directory_validators.constants import choices
-
-from django.conf import settings
-
-api_client = DirectoryAPIClient(
-    base_url=settings.API_CLIENT_BASE_URL,
-    api_key=settings.API_CLIENT_KEY,
-)
 
 EMPLOYEE_CHOICES = {key: value for key, value in choices.EMPLOYEES}
 SECTOR_CHOICES = {key: value for key, value in choices.COMPANY_CLASSIFICATIONS}

--- a/enrolment/tests/test_views.py
+++ b/enrolment/tests/test_views.py
@@ -271,8 +271,6 @@ def test_enrolment_form_complete_api_client_fail(company_request):
                    return_value={})
 @mock.patch.object(UserCompanyProfileEditView, 'serialize_form_data',
                    mock.Mock(return_value={'field': 'value'}))
-@mock.patch.object(api_client.company, 'retrieve_profile',
-                   mock.Mock(return_value=mock.Mock(json=lambda: {})))
 @mock.patch.object(api_client.company, 'update_profile')
 def test_company_profile_edit_api_client_call(
         mock_update_profile, rf, client, company_request):
@@ -292,8 +290,6 @@ def test_company_profile_edit_api_client_call(
 @mock.patch.object(UserCompanyProfileEditView, 'serialize_form_data',
                    mock.Mock(return_value={}))
 @mock.patch.object(api_client.company, 'update_profile', api_response_200)
-@mock.patch.object(api_client.company, 'retrieve_profile',
-                   mock.Mock(return_value=mock.Mock(json=lambda: {})))
 def test_company_profile_edit_api_client_success(company_request):
     view = UserCompanyProfileEditView()
     view.request = company_request
@@ -307,8 +303,6 @@ def test_company_profile_edit_api_client_success(company_request):
                    mock.Mock(return_value={}))
 @mock.patch.object(UserCompanyProfileEditView, 'serialize_form_data',
                    mock.Mock(return_value={}))
-@mock.patch.object(api_client.company, 'retrieve_profile',
-                   mock.Mock(return_value=mock.Mock(json=lambda: {})))
 @mock.patch.object(api_client.company, 'update_profile', api_response_400)
 def test_company_profile_edit_api_client_failure(company_request):
 
@@ -492,8 +486,6 @@ def test_company_profile_logo_api_client_failure(company_request):
             mock.Mock(return_value=True))
 @mock.patch.object(UserCompanyDescriptionEditView, 'serialize_form_data',
                    lambda x: {'field': 'value'})
-@mock.patch.object(api_client.company, 'retrieve_profile',
-                   mock.Mock(return_value=mock.Mock(json=lambda: {})))
 @mock.patch.object(api_client.company, 'update_profile')
 def test_company_profile_description_api_client_call(mock_update_profile,
                                                      company_request):
@@ -510,8 +502,6 @@ def test_company_profile_description_api_client_call(mock_update_profile,
             mock.Mock(return_value=True))
 @mock.patch.object(UserCompanyDescriptionEditView, 'serialize_form_data',
                    mock.Mock(return_value={}))
-@mock.patch.object(api_client.company, 'retrieve_profile',
-                   mock.Mock(return_value=mock.Mock(json=lambda: {})))
 @mock.patch.object(api_client.company, 'update_profile', api_response_200)
 def test_company_profile_description_api_client_success(company_request):
 
@@ -525,8 +515,6 @@ def test_company_profile_description_api_client_success(company_request):
             mock.Mock(return_value=True))
 @mock.patch.object(UserCompanyDescriptionEditView, 'serialize_form_data',
                    mock.Mock(return_value={}))
-@mock.patch.object(api_client.company, 'retrieve_profile',
-                   mock.Mock(return_value=mock.Mock(json=lambda: {})))
 @mock.patch.object(api_client.company, 'update_profile', api_response_400)
 def test_company_profile_description_api_client_failure(company_request):
 

--- a/enrolment/validators.py
+++ b/enrolment/validators.py
@@ -2,16 +2,9 @@
 # directory-validators
 import http
 
-from directory_api_client.client import DirectoryAPIClient
-
 from django.forms import ValidationError
-from django.conf import settings
 
-
-api_client = DirectoryAPIClient(
-    base_url=settings.API_CLIENT_BASE_URL,
-    api_key=settings.API_CLIENT_KEY,
-)
+from api_client import api_client
 
 
 def company_number(value):

--- a/enrolment/views.py
+++ b/enrolment/views.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-from directory_api_client.client import DirectoryAPIClient
 from formtools.wizard.views import SessionWizardView
 
 from django.conf import settings
@@ -13,15 +12,11 @@ from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
 from django.views.generic.base import View
 
+from api_client import api_client
 from enrolment import forms, helpers
 from enrolment import constants
 from sso.utils import SSOLoginRequiredMixin
 
-
-api_client = DirectoryAPIClient(
-    base_url=settings.API_CLIENT_BASE_URL,
-    api_key=settings.API_CLIENT_KEY,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/makefile
+++ b/makefile
@@ -31,6 +31,7 @@ docker_run:
 	docker-compose up --build
 
 DOCKER_SET_DEBUG_ENV_VARS := \
+	export DIRECTORY_UI_API_CLIENT_CLASS_NAME=unit-test; \
 	export DIRECTORY_UI_API_CLIENT_KEY=debug; \
 	export DIRECTORY_UI_API_CLIENT_BASE_URL=http://api.trade.great.dev:8000; \
 	export DIRECTORY_UI_SSO_API_CLIENT_KEY=debug; \
@@ -79,6 +80,7 @@ DEBUG_SET_ENV_VARS := \
 	export PORT=8001; \
 	export SECRET_KEY=debug; \
 	export DEBUG=true ;\
+	export API_CLIENT_CLASS_NAME=unit-test; \
 	export API_CLIENT_KEY=debug; \
 	export API_CLIENT_BASE_URL=http://api.trade.great.dev:8000; \
 	export SSO_API_CLIENT_KEY=debug; \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ raven==5.19.0
 requests==2.10.0
 whitenoise==3.1
 git+https://github.com/uktrade/directory-validators.git@1.0.0#egg=directory_validators
-git+https://github.com/uktrade/directory-api-client.git@0.4.0#egg=directory_api_client
+git+https://github.com/uktrade/directory-api-client.git@0.5.0#egg=directory_api_client
 git+https://github.com/uktrade/directory-sso-api-client.git@1.0.1#egg=directory_sso_api_client
 git+https://github.com/uktrade/directory-constants.git@1.0.0#egg=directory_constants

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -144,3 +144,10 @@ VALIDATOR_MAX_LOGO_SIZE_BYTES = int(os.getenv(
 ))
 
 COMPANIES_HOUSE_SEARCH_URL = os.environ["COMPANIES_HOUSE_SEARCH_URL"]
+
+API_CLIENT_CLASSES = {
+    'default': 'directory_api_client.client.DirectoryAPIClient',
+    'unit-test': 'directory_api_client.dummy_client.DummyDirectoryAPIClient',
+}
+API_CLIENT_CLASS_NAME = os.getenv('API_CLIENT_CLASS_NAME', 'default')
+API_CLIENT_CLASS = API_CLIENT_CLASSES[API_CLIENT_CLASS_NAME]


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-427)

 - prevents api calls being made in unit tests
 - reduces number of mocks needed.