### PR TITLE
Show "letter sent" confirmation

### DIFF
--- a/company/conftest.py
+++ b/company/conftest.py
@@ -19,6 +19,7 @@ def retrieve_profile_data():
         'employees': '501-1000',
         'date_of_creation': '2015-03-02',
         'verified_with_code': True,
+        'is_verification_letter_sent': False,
         'contact_details': {
             'email_full_name': 'Jeremy',
             'email_address': 'test@example.com',
@@ -120,6 +121,16 @@ def api_response_company_profile_200(retrieve_profile_data):
     response = requests.Response()
     response.status_code = http.client.OK
     response.json = lambda: deepcopy(retrieve_profile_data)
+    return response
+
+
+@pytest.fixture
+def api_response_company_profile_letter_sent_200(retrieve_profile_data):
+    profile_data = deepcopy(retrieve_profile_data)
+    profile_data['is_verification_letter_sent'] = True
+    response = requests.Response()
+    response.status_code = http.client.OK
+    response.json = lambda: profile_data
     return response
 
 

--- a/company/templates/company-profile-form-letter-sent.html
+++ b/company/templates/company-profile-form-letter-sent.html
@@ -1,0 +1,13 @@
+{% extends 'enrolment-base.html' %}
+{% load staticfiles %}
+{% block head_title %}Company address - Find a Buyer - GREAT.gov.uk{% endblock %}
+{% block sub_header %}{# prevent the subheader from showing on form pages #}{% endblock %}
+{% block formarea %}
+	<div class="container">
+		<h1>We've sent your verification letter</h1>
+		<p>
+			You should receive your verification letter within a week. When you receive the letter, please log in to GREAT.gov.uk to enter your verification profile to publish your company profile.
+		</p>
+		<p><a href="{% url 'company-detail' %}">View or amend your company profile</p>
+	</div>
+{%endblock formarea %}


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-506)

We will show 'letter sent' page instead of redirecting the user immediately to their profile.

If the verification letter is already sent then the user will not be presented with the 'check your address' last step - so they will see 4 instead of 5 steps. Those users will also not not be shown the 'letter sent' page.

# Final 'check the address page (for users who have not yet had the letter sent)
![image](https://cloud.githubusercontent.com/assets/5485798/21313257/aabd98fe-c5e8-11e6-9086-9b93aeeb163d.png)

# letter sent confirmation page
![image](https://cloud.githubusercontent.com/assets/5485798/21313231/86d41bf2-c5e8-11e6-8754-5af172f541ab.png)

# 5 steps (for users who have not yet had the letter sent)
![image](https://cloud.githubusercontent.com/assets/5485798/21313271/be875aaa-c5e8-11e6-8909-2d63a6bfbed6.png)

# 4 steps (for users who have the letter already sent)
![image](https://cloud.githubusercontent.com/assets/5485798/21313282/cf481a82-c5e8-11e6-8eaa-bd6766b1aa36.png)
